### PR TITLE
Replace void* with nullptr_t

### DIFF
--- a/RareCppLib/Json.h
+++ b/RareCppLib/Json.h
@@ -136,7 +136,7 @@ namespace Json
         using NoField = Fields::Field<>;
 
         template <typename T>
-        using ReflectedField = Fields::Field<T, void*, 0, IsRoot>;
+        using ReflectedField = Fields::Field<T, nullptr_t, 0, IsRoot>;
 
         struct Context
         {
@@ -899,13 +899,13 @@ namespace Json
                 size_t FieldIndex = NoFieldIndex, typename OpAnnotations = Annotate<>, typename Field = NoField, Statics statics = Statics::Excluded,
                 bool PrettyPrint = false, size_t TotalParentIterables = 0, size_t IndentLevel = 0, const char* indent = twoSpaces>
             static constexpr bool HaveSpecialization =
-                is_specialized<Customize<Object, Value, Field::Index, OpAnnotations, Field, statics,
+                is_specialized<Customize<Object, Value, FieldIndex, OpAnnotations, Field, statics,
                     PrettyPrint, TotalParentIterables, IndentLevel, indent>>::value || // Fully specialized
-                is_specialized<Customize<Object, Value, Field::Index, OpAnnotations, Field>>::value || // Customize<5args> specialized
-                is_specialized<Customize<Object, Value, Field::Index, OpAnnotations>>::value || // Customize<4args> specialized
-                is_specialized<Customize<Object, Value, Field::Index>>::value || // Customize<3args> specialized
+                is_specialized<Customize<Object, Value, FieldIndex, OpAnnotations, Field>>::value || // Customize<5args> specialized
+                is_specialized<Customize<Object, Value, FieldIndex, OpAnnotations>>::value || // Customize<4args> specialized
+                is_specialized<Customize<Object, Value, FieldIndex>>::value || // Customize<3args> specialized
                 is_specialized<Customize<Object, Value>>::value || // Customize<2args> specialized
-                is_specialized<Customize<Object, Value, Field::Index, Annotate<>, Field>>::value || // Customize<5args>, OpAnnotations defaulted
+                is_specialized<Customize<Object, Value, FieldIndex, Annotate<>, Field>>::value || // Customize<5args>, OpAnnotations defaulted
                 is_specialized<Customize<Object, Value, NoFieldIndex, OpAnnotations, Field>>::value || // Customize<5args>, FieldIndex defaulted
                 is_specialized<Customize<Object, Value, NoFieldIndex, Annotate<>, Field>>::value || // Customize<5args>, both defaulted
                 is_specialized<Customize<Object, Value, NoFieldIndex, OpAnnotations>>::value || // Customize<4args>, FieldIndex defaulted

--- a/RareCppLib/Reflect.h
+++ b/RareCppLib/Reflect.h
@@ -751,11 +751,11 @@ namespace Reflect
 
     namespace Fields
     {
-        template <typename T = void, typename FieldPointer = void*, size_t FieldIndex = 0, typename Annotations = Annotate<>>
+        template <typename T = void, typename FieldPointer = nullptr_t, size_t FieldIndex = 0, typename Annotations = Annotate<>>
         struct Field;
     
         template <>
-        struct Field<void, void*, 0, void> {
+        struct Field<void, nullptr_t, 0, Annotate<>> {
             const char* name;
             const char* typeStr;
             size_t arraySize;
@@ -772,12 +772,12 @@ namespace Reflect
             bool isReflected;
 
             using Type = T;
-            using Pointer = std::conditional_t<std::is_reference_v<T>, void*, FieldPointer>;
+            using Pointer = std::conditional_t<std::is_reference_v<T>, nullptr_t, FieldPointer>;
 
             Pointer p;
         
             static constexpr size_t Index = FieldIndex;
-            static constexpr bool IsStatic = !std::is_member_pointer<FieldPointer>::value && !std::is_same<void*, FieldPointer>::value;
+            static constexpr bool IsStatic = !std::is_member_pointer<FieldPointer>::value && !std::is_same<nullptr_t, FieldPointer>::value;
 
             template <typename Annotation>
             static constexpr bool HasAnnotation = Annotate<Annotations>::template Has<Annotation>;
@@ -793,7 +793,7 @@ namespace Reflect
     static constexpr auto nameStr = ConstexprStr::substr<ConstexprStr::length_after_last(#x, ' ')>(&#x[0]+ConstexprStr::find_last_of(#x, ' ')+1); \
     static constexpr auto typeStr = ExtendedTypeSupport::TypeName<RHS(x)>(); \
     template <typename T> static constexpr decltype(&T::RHS(x)) GetPointerType(int); \
-    template <typename T> static constexpr void* GetPointerType(...); \
+    template <typename T> static constexpr nullptr_t GetPointerType(...); \
     using Pointer = decltype(GetPointerType<ClassType>(0)); \
     using Field = Fields::Field<Class::RHS(x), Pointer, IndexOf::RHS(x), Annotate<LHS(x)>::Annotations>; \
     template <typename T, bool IsReference> struct GetPointer { static constexpr Field::Pointer value = &T::RHS(x); }; \

--- a/RareCppTest/FieldTest.cpp
+++ b/RareCppTest/FieldTest.cpp
@@ -80,7 +80,7 @@ TEST(ReflectionSupportTest, ReferencesFieldTemplated)
     bool fieldIsIterable = false;
     bool fieldIsReflected = false;
 
-    Field<decltype(ReferencesTestStruct::testVal), void*, fieldIndex> field =
+    Field<decltype(ReferencesTestStruct::testVal), nullptr_t, fieldIndex> field =
     { fieldName, fieldTypeStr, fieldArraySize, fieldIsIterable, fieldIsReflected, nullptr };
     using IntField = decltype(field);
 
@@ -93,7 +93,7 @@ TEST(ReflectionSupportTest, ReferencesFieldTemplated)
     bool isEqual = std::is_same<int&, IntField::Type>::value;
     EXPECT_TRUE(isEqual);
 
-    isEqual = std::is_same<IntField::Pointer, void*>::value;
+    isEqual = std::is_same<IntField::Pointer, nullptr_t>::value;
     EXPECT_TRUE(isEqual);
 
     EXPECT_TRUE(field.p == nullptr);
@@ -105,7 +105,7 @@ TEST(ReflectionSupportTest, ReferencesFieldTemplated)
     { fieldName, fieldTypeStr, fieldArraySize, fieldIsIterable, fieldIsReflected, nullptr };
     using StaticIntField = decltype(staticField);
 
-    isEqual = std::is_same<StaticIntField::Pointer, void*>::value;
+    isEqual = std::is_same<StaticIntField::Pointer, nullptr_t>::value;
     EXPECT_TRUE(isEqual);
 
     EXPECT_TRUE(staticField.p == nullptr);

--- a/RareCppTest/JsonInputTest.cpp
+++ b/RareCppTest/JsonInputTest.cpp
@@ -1279,7 +1279,7 @@ TEST_HEADER(JsonInputRead, ValuePair)
     std::pair<std::string, bool> testPair = std::pair<std::string, bool>("", true);
     EXPECT_TRUE(testPair.second);
     std::stringstream testPairStream("\"aPair\":false ,");
-    Json::Read::Value<true, Fields::Field<>>(testPairStream, Json::context, c, placeholderObj, testPair);
+    Json::Read::Value<true, Fields::Field<decltype(testPair)>>(testPairStream, Json::context, c, placeholderObj, testPair);
     EXPECT_FALSE(testPair.second);
 }
 

--- a/RareCppTest/JsonTest.cpp
+++ b/RareCppTest/JsonTest.cpp
@@ -2657,7 +2657,7 @@ TEST_HEADER(JsonOutputPut, Value)
         booleanStream,
         shortIntStream;
 
-    using AField = Fields::Field<>;
+    using AField = Fields::Field<int>;
 
     int placeholderObj = 0;
     CustomizeFullySpecialized customized;
@@ -2720,7 +2720,7 @@ TEST_HEADER(JsonOutputPut, PairValue)
     TestStreamType pairValueStream;
     std::pair<std::string, int> pair = std::pair("integer", 555);
     int placeholderObj = 0;
-    Json::Put::Value<Annotate<>, Fields::Field<>, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(pairValueStream, Json::context, placeholderObj, pair);
+    Json::Put::Value<Annotate<>, Fields::Field<decltype(pair)>, Json::Statics::Excluded, false, 0, 0, Json::twoSpaces, int, true>(pairValueStream, Json::context, placeholderObj, pair);
     EXPECT_STREQ("\"integer\":555", pairValueStream.str().c_str());
 }
 

--- a/RareCppTest/ReflectTest.cpp
+++ b/RareCppTest/ReflectTest.cpp
@@ -525,8 +525,8 @@ public:
     float second;
 
     struct Class {
-        struct first_ { static constexpr Fields::Field<int> field = { "first", "int", 0, false, false }; };
-        struct second_ { static constexpr Fields::Field<float> field = { "second", "float", 0, false, false }; };
+        struct first_ { static constexpr Fields::Field<decltype(first), decltype(&first), 0, Annotate<>> field = { "first", "int", 0, false, false }; };
+        struct second_ { static constexpr Fields::Field<decltype(second), decltype(&second), 1, Annotate<>> field = { "second", "float", 0, false, false }; };
         static constexpr Fields::Field<> Fields[2] = {
             GET_FIELD(() first)
             GET_FIELD(() second)


### PR DESCRIPTION
Use a stronger type for the default field template.

As this doesn't pertain directly to implementing function reflection nor advanced annotations and it's working on all three compilers I'm pushing it to DEV.