### PR TITLE
Feature/increase compatibility

### DIFF
--- a/RareCpp/Main.cpp
+++ b/RareCpp/Main.cpp
@@ -2,6 +2,7 @@
 #include "../RareCppLib/Reflect.h"
 #include <typeinfo>
 #include <memory>
+using Reflect::is_reflected;
 using Json::Statics;
 
 int A::second = 0;

--- a/RareCpp/Main.cpp
+++ b/RareCpp/Main.cpp
@@ -4,8 +4,6 @@
 #include <memory>
 using Json::Statics;
 
-ENABLE_JSON;
-
 int A::second = 0;
 int & A::secondReference = A::second;
 

--- a/RareCpp/Main.h
+++ b/RareCpp/Main.h
@@ -2,8 +2,8 @@
 #define MAIN_H
 #include "../RareCppLib/Json.h"
 #include <iostream>
-using namespace Reflect;
 using ExtendedTypeSupport::TypeToStr;
+using Reflect::Super;
 using u8 = uint8_t;
 
 namespace Rest

--- a/RareCppLib/Json.h
+++ b/RareCppLib/Json.h
@@ -150,7 +150,7 @@ namespace Json
         using NoField = Fields::Field<>;
 
         template <typename T>
-        using ReflectedField = Fields::Field<T, nullptr_t, 0, IsRoot>;
+        using ReflectedField = Fields::Field<T, std::nullptr_t, 0, IsRoot>;
 
         struct Context
         {

--- a/RareCppLib/Reflect.h
+++ b/RareCppLib/Reflect.h
@@ -208,13 +208,6 @@ namespace ConstexprStr
         }
         char value[N + 1];
     };
-
-    template <size_t N> constexpr size_t find_last_of(const char(&s)[N], const char character)
-    {
-        size_t pos = N-1;
-        for ( ; pos < N && s[pos] != character; pos-- );
-        return pos;
-    }
 };
 
 namespace ExtendedTypeSupport

--- a/RareCppLib/Reflect.h
+++ b/RareCppLib/Reflect.h
@@ -874,7 +874,7 @@ namespace Reflect
     template <typename T, bool NoNote> struct GetNote { static constexpr auto & value = Class::NoNote; }; \
     template <typename T> struct GetNote<T, false> { static constexpr auto & value = T::x##_note; }; \
     using NoteType = decltype(idNote<ClassType>(0)); \
-    using Field = Fields::Field<Type, Pointer, IndexOf::x, NoteType>; \
+    using Field = Reflect::Fields::Field<Type, Pointer, IndexOf::x, NoteType>; \
     static constexpr Field field = { &nameStr.value[0], &typeStr.value[0], GetPointer<ClassType, std::is_reference_v<Type>>::value, \
         GetNote<ClassType, std::is_same_v<decltype(Class::NoNote), NoteType>>::value }; \
     CLANG_ONLY(x) \
@@ -894,13 +894,13 @@ namespace Reflect
 struct Class { \
     using ClassType = objectType; \
     enum_t(IndexOf, size_t, { FOR_EACH(GET_FIELD_NAME, __VA_ARGS__) }); \
-    static constexpr NoAnnotation NoNote {}; \
+    static constexpr Reflect::NoAnnotation NoNote {}; \
     using Annotations = decltype(NoNote); \
     static constexpr Annotations & annotations = NoNote; \
     FOR_EACH(DESCRIBE_FIELD, __VA_ARGS__) \
     static constexpr size_t TotalFields = COUNT_ARGUMENTS(__VA_ARGS__); \
     static constexpr size_t TotalStaticFields = 0 FOR_EACH(ADD_IF_STATIC, __VA_ARGS__); \
-    static constexpr Fields::Field<> Fields[TotalFields] = { FOR_EACH(GET_FIELD, __VA_ARGS__) }; \
+    static constexpr Reflect::Fields::Field<> Fields[TotalFields] = { FOR_EACH(GET_FIELD, __VA_ARGS__) }; \
     template <typename Function> constexpr static void ForEachField(Function function) { FOR_EACH(USE_FIELD, __VA_ARGS__) } \
     template <typename Function> static void ForEachField(objectType & object, Function function) { FOR_EACH(USE_FIELD_VALUE, __VA_ARGS__) } \
     template <typename Function> static void ForEachField(const objectType & object, Function function) { FOR_EACH(USE_FIELD_VALUE, __VA_ARGS__) } \
@@ -909,7 +909,7 @@ struct Class { \
     template <typename Function> static void FieldAt(objectType & object, size_t fieldIndex, Function function) { \
         switch ( fieldIndex ) { FOR_EACH(USE_FIELD_VALUE_AT, __VA_ARGS__) } } \
 }; \
-using Supers = Inherit<Class::ClassType, Class::Annotations>;
+using Supers = Reflect::Inherit<Class::ClassType, Class::Annotations>;
 
 
 /// REFLECT_NOTED is exactly the same as REFLECT except this signals that objectType itself is annotated
@@ -917,13 +917,13 @@ using Supers = Inherit<Class::ClassType, Class::Annotations>;
 struct Class { \
     using ClassType = objectType; \
     enum_t(IndexOf, size_t, { FOR_EACH(GET_FIELD_NAME, __VA_ARGS__) }); \
-    static constexpr NoAnnotation NoNote {}; \
+    static constexpr Reflect::NoAnnotation NoNote {}; \
     using Annotations = decltype(objectType##_note); \
     static constexpr Annotations & annotations = objectType##_note; \
     FOR_EACH(DESCRIBE_FIELD, __VA_ARGS__) \
     static constexpr size_t TotalFields = COUNT_ARGUMENTS(__VA_ARGS__); \
     static constexpr size_t TotalStaticFields = 0 FOR_EACH(ADD_IF_STATIC, __VA_ARGS__); \
-    static constexpr Fields::Field<> Fields[TotalFields] = { FOR_EACH(GET_FIELD, __VA_ARGS__) }; \
+    static constexpr Reflect::Fields::Field<> Fields[TotalFields] = { FOR_EACH(GET_FIELD, __VA_ARGS__) }; \
     template <typename Function> constexpr static void ForEachField(Function function) { FOR_EACH(USE_FIELD, __VA_ARGS__) } \
     template <typename Function> static void ForEachField(objectType & object, Function function) { FOR_EACH(USE_FIELD_VALUE, __VA_ARGS__) } \
     template <typename Function> static void ForEachField(const objectType & object, Function function) { FOR_EACH(USE_FIELD_VALUE, __VA_ARGS__) } \
@@ -932,7 +932,7 @@ struct Class { \
     template <typename Function> static void FieldAt(objectType & object, size_t fieldIndex, Function function) { \
         switch ( fieldIndex ) { FOR_EACH(USE_FIELD_VALUE_AT, __VA_ARGS__) } } \
 }; \
-using Supers = Inherit<Class::ClassType, Class::Annotations>;
+using Supers = Reflect::Inherit<Class::ClassType, Class::Annotations>;
 
 
 /// REFLECT_EMPTY is used to reflect an annotated class with no reflected fields
@@ -943,14 +943,14 @@ struct Class { \
     static constexpr Annotations & annotations = objectType##_note; \
     static constexpr size_t TotalFields = 0; \
     static constexpr size_t TotalStaticFields = 0; \
-    static constexpr Fields::Field<> Fields[1] = { { "", "" } }; \
+    static constexpr Reflect::Fields::Field<> Fields[1] = { { "", "" } }; \
     template <typename Function> constexpr static void ForEachField(Function function) {} \
     template <typename Function> static void ForEachField(objectType & object, Function function) {} \
     template <typename Function> static void ForEachField(const objectType & object, Function function) { } \
     template <typename Function> constexpr static void FieldAt(size_t fieldIndex, Function function) {} \
     template <typename Function> static void FieldAt(objectType & object, size_t fieldIndex, Function function) {} \
 }; \
-using Supers = Inherit<Class::ClassType, Class::Annotations>;
+using Supers = Reflect::Inherit<Class::ClassType, Class::Annotations>;
 
 
     template <typename T, typename = decltype(T::Class::TotalFields)> static constexpr std::true_type typeHasReflection(int);

--- a/RareCppLib/Reflect.h
+++ b/RareCppLib/Reflect.h
@@ -813,11 +813,11 @@ namespace Reflect
 
     namespace Fields
     {
-        template <typename T = void, typename FieldPointer = nullptr_t, size_t FieldIndex = 0, typename Annotations = NoAnnotation>
+        template <typename T = void, typename FieldPointer = std::nullptr_t, size_t FieldIndex = 0, typename Annotations = NoAnnotation>
         struct Field;
     
         template <>
-        struct Field<void, nullptr_t, 0, NoAnnotation> {
+        struct Field<void, std::nullptr_t, 0, NoAnnotation> {
             const char* name;
             const char* typeStr;
         };
@@ -828,14 +828,14 @@ namespace Reflect
             const char* typeStr;
 
             using Type = T;
-            using Pointer = std::conditional_t<std::is_reference_v<T>, nullptr_t, FieldPointer>;
+            using Pointer = std::conditional_t<std::is_reference_v<T>, std::nullptr_t, FieldPointer>;
             using Annotations = FieldAnnotations;
 
             Pointer p;
             const Annotations & annotations;
         
             static constexpr size_t Index = FieldIndex;
-            static constexpr bool IsStatic = !std::is_member_pointer<FieldPointer>::value && !std::is_same<nullptr_t, FieldPointer>::value;
+            static constexpr bool IsStatic = !std::is_member_pointer<FieldPointer>::value && !std::is_same<std::nullptr_t, FieldPointer>::value;
             static constexpr bool IsFunction = std::is_function_v<T> || std::is_same_v<T, FieldPointer>;
 
             template <typename Annotation>
@@ -868,12 +868,12 @@ namespace Reflect
 
 #define DESCRIBE_FIELD(x) struct x##_ { \
     template <typename T> static constexpr ExtendedTypeSupport::TypePair<decltype(T::x), decltype(&T::x)> identify(int); \
-    template <typename T> static constexpr ExtendedTypeSupport::TypePair<decltype(T::x), nullptr_t> identify(unsigned int); \
+    template <typename T> static constexpr ExtendedTypeSupport::TypePair<decltype(T::x), std::nullptr_t> identify(unsigned int); \
     template <typename T> static constexpr ExtendedTypeSupport::TypePair<decltype(&T::x), decltype(&T::x)> identify(...); \
     using Type = decltype(identify<ClassType>(0))::Left; \
     using Pointer = decltype(identify<ClassType>(0))::Right; \
     template <typename T, bool IsReference> struct GetPointer { static constexpr auto value = &T::x; }; \
-    template <typename T> struct GetPointer<T, true> { static constexpr nullptr_t value = nullptr; }; \
+    template <typename T> struct GetPointer<T, true> { static constexpr std::nullptr_t value = nullptr; }; \
     static constexpr auto nameStr = ConstexprStr::substr<std::string_view(#x).size()>(&#x[0]); \
     static constexpr auto typeStr = ExtendedTypeSupport::TypeName<Type>(); \
     template <typename T> static constexpr decltype(T::x##_note) idNote(int); \

--- a/RareCppTest/CMakeLists.txt
+++ b/RareCppTest/CMakeLists.txt
@@ -11,7 +11,7 @@ set(Sources
   ExtendedTypeSupportTest.cpp
   FieldTest.cpp
   GenericMacroTest.cpp
-  JsonDefinition.cpp
+  InheritTest.cpp
   JsonInputTest.cpp
   JsonInputTestBuffered.cpp
   JsonInputTestUnbuffered.cpp

--- a/RareCppTest/ConstexprStrTest.cpp
+++ b/RareCppTest/ConstexprStrTest.cpp
@@ -1,18 +1,5 @@
 #include <gtest/gtest.h>
 #include "../RareCppLib/Reflect.h"
-#include <array>
-#include <vector>
-#include <deque>
-#include <forward_list>
-#include <list>
-#include <stack>
-#include <queue>
-#include <set>
-#include <map>
-#include <unordered_set>
-#include <unordered_map>
-#include <utility>
-#include <type_traits>
 using namespace ConstexprStr;
 
 TEST(ConstexprStrTest, ConstexprStrSubstr)
@@ -43,14 +30,4 @@ TEST(ConstexprStrTest, ConstexprStrSubstr)
     EXPECT_STREQ("ef", substr<2>(&"abcdef"[0]+4).value);
 
     EXPECT_STREQ("f", substr<1>(&"abcdef"[0]+5).value);
-}
-
-TEST(ConstexprStrTest, ConstexprStrFindLastOf)
-{
-    EXPECT_EQ(6, find_last_of("abcdefabcdef", 'a'));
-    EXPECT_EQ(7, find_last_of("abcdefabcdef", 'b'));
-    EXPECT_EQ(8, find_last_of("abcdefabcdef", 'c'));
-    EXPECT_EQ(9, find_last_of("abcdefabcdef", 'd'));
-    EXPECT_EQ(10, find_last_of("abcdefabcdef", 'e'));
-    EXPECT_EQ(11, find_last_of("abcdefabcdef", 'f'));
 }

--- a/RareCppTest/FieldTest.cpp
+++ b/RareCppTest/FieldTest.cpp
@@ -9,7 +9,7 @@ TEST(ReflectionFieldTest, FieldSimple)
     char fieldTypeStr[] = "int";
 
     Field<> field = { fieldName, fieldTypeStr };
-    bool isEqual = std::is_same<decltype(field), Field<void, nullptr_t, 0, NoAnnotation>>::value;
+    bool isEqual = std::is_same<decltype(field), Field<void, std::nullptr_t, 0, NoAnnotation>>::value;
     EXPECT_TRUE(isEqual);
     
     EXPECT_STREQ(fieldName, field.name);
@@ -77,7 +77,7 @@ TEST(ReflectionFieldTest, ReferencesFieldTemplated)
     bool fieldIsFunction = false;
     NoAnnotation noAnnotation{};
 
-    Field<decltype(ReferencesTestStruct::testVal), nullptr_t, fieldIndex> field =
+    Field<decltype(ReferencesTestStruct::testVal), std::nullptr_t, fieldIndex> field =
     { fieldName, fieldTypeStr, nullptr, noAnnotation };
     using IntField = decltype(field);
 
@@ -87,7 +87,7 @@ TEST(ReflectionFieldTest, ReferencesFieldTemplated)
     bool isEqual = std::is_same<int&, IntField::Type>::value;
     EXPECT_TRUE(isEqual);
 
-    isEqual = std::is_same<nullptr_t, IntField::Pointer>::value;
+    isEqual = std::is_same<std::nullptr_t, IntField::Pointer>::value;
     EXPECT_TRUE(isEqual);
 
     isEqual = std::is_same<NoAnnotation, IntField::Annotations>::value;
@@ -103,7 +103,7 @@ TEST(ReflectionFieldTest, ReferencesFieldTemplated)
     { fieldName, fieldTypeStr, nullptr, noAnnotation };
     using StaticIntField = decltype(staticField);
 
-    isEqual = std::is_same<StaticIntField::Pointer, nullptr_t>::value;
+    isEqual = std::is_same<StaticIntField::Pointer, std::nullptr_t>::value;
     EXPECT_TRUE(isEqual);
 
     EXPECT_TRUE(staticField.p == nullptr);

--- a/RareCppTest/InheritTest.cpp
+++ b/RareCppTest/InheritTest.cpp
@@ -329,7 +329,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -344,7 +344,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -361,7 +361,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -376,7 +376,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -394,7 +394,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -404,7 +404,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -422,7 +422,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -432,7 +432,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -452,7 +452,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -462,7 +462,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -480,7 +480,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -490,7 +490,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -511,7 +511,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -521,7 +521,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -531,7 +531,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -549,7 +549,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -559,7 +559,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -571,7 +571,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -589,7 +589,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -599,7 +599,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -609,7 +609,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -627,7 +627,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -637,7 +637,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -649,7 +649,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstance)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -685,7 +685,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -700,7 +700,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -717,7 +717,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -732,7 +732,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -750,7 +750,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -760,7 +760,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -778,7 +778,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -788,7 +788,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -808,7 +808,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -818,7 +818,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -836,7 +836,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -846,7 +846,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -867,7 +867,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -877,7 +877,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -887,7 +887,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -905,7 +905,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -915,7 +915,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -927,7 +927,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -945,7 +945,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -955,7 +955,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -965,7 +965,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -983,7 +983,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
         if constexpr ( superInfo.Index == 0 )
         {
-            bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S1, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -993,7 +993,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 1 )
         {
-            bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S2, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -1005,7 +1005,7 @@ TEST(ReflectInheritanceTest, InheritForEachInstanceConst)
         }
         else if constexpr ( superInfo.Index == 2 )
         {
-            bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritSuper_S3, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -1349,7 +1349,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1364,7 +1364,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1381,7 +1381,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1396,7 +1396,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1416,7 +1416,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1426,7 +1426,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1447,7 +1447,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1457,7 +1457,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1480,7 +1480,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1490,7 +1490,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1511,7 +1511,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1521,7 +1521,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1545,7 +1545,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1555,7 +1555,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1565,7 +1565,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1586,7 +1586,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1596,7 +1596,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1608,7 +1608,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1629,7 +1629,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1639,7 +1639,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1649,7 +1649,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1670,7 +1670,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1680,7 +1680,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1692,7 +1692,7 @@ TEST(ReflectInheritanceTest, InheritAtInstance)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1729,7 +1729,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1744,7 +1744,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1761,7 +1761,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1776,7 +1776,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritSuper_S1, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -1796,7 +1796,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1806,7 +1806,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1827,7 +1827,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1837,7 +1837,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1860,7 +1860,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1870,7 +1870,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1891,7 +1891,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1901,7 +1901,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1925,7 +1925,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1935,7 +1935,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1945,7 +1945,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1966,7 +1966,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1976,7 +1976,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -1988,7 +1988,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2009,7 +2009,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2019,7 +2019,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2029,7 +2029,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2050,7 +2050,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
             if constexpr ( superInfo.Index == 0 )
             {
-                bool isSame = std::is_same<InheritSuper_S1, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S1, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S1, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2060,7 +2060,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 1 )
             {
-                bool isSame = std::is_same<InheritSuper_S2, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S2, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S2, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2072,7 +2072,7 @@ TEST(ReflectInheritanceTest, InheritAtInstanceConst)
             }
             else if constexpr ( superInfo.Index == 2 )
             {
-                bool isSame = std::is_same<InheritSuper_S3, std::remove_reference<decltype(super)>::type>::value;
+                bool isSame = std::is_same<InheritSuper_S3, typename std::remove_reference<decltype(super)>::type>::value;
                 EXPECT_TRUE(isSame);
                 isSame = std::is_same<InheritSuper_S3, InfoType>::value;
                 EXPECT_TRUE(isSame);
@@ -2445,7 +2445,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritParent, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritParent, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritParent, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -2459,7 +2459,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
             using Info = decltype(superInfo);
             using InfoType = typename Info::Type;
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-            bool isSame = std::is_same<InheritGrandparent, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritGrandparent, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritGrandparent, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -2482,7 +2482,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritParent, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritParent, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritParent, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -2496,7 +2496,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
             using Info = decltype(superInfo);
             using InfoType = typename Info::Type;
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-            bool isSame = std::is_same<InheritGrandparent, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritGrandparent, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritGrandparent, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -2552,7 +2552,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritParent, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritParent, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritParent, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -2566,7 +2566,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
             using Info = decltype(superInfo);
             using InfoType = typename Info::Type;
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-            bool isSame = std::is_same<InheritGrandparent, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritGrandparent, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritGrandparent, InfoType>::value;
             EXPECT_TRUE(isSame);
@@ -2589,7 +2589,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
         using Info = decltype(superInfo);
         using InfoType = typename Info::Type;
         using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-        bool isSame = std::is_same<InheritParent, std::remove_reference<decltype(super)>::type>::value;
+        bool isSame = std::is_same<InheritParent, typename std::remove_reference<decltype(super)>::type>::value;
         EXPECT_TRUE(isSame);
         isSame = std::is_same<InheritParent, InfoType>::value;
         EXPECT_TRUE(isSame);
@@ -2603,7 +2603,7 @@ TEST(ReflectInheritanceTest, InheritRecursion)
             using Info = decltype(superInfo);
             using InfoType = typename Info::Type;
             using InfoAnnotations = typename std::remove_reference<typename std::remove_const<typename Info::Annotations>::type>::type;
-            bool isSame = std::is_same<InheritGrandparent, std::remove_reference<decltype(super)>::type>::value;
+            bool isSame = std::is_same<InheritGrandparent, typename std::remove_reference<decltype(super)>::type>::value;
             EXPECT_TRUE(isSame);
             isSame = std::is_same<InheritGrandparent, InfoType>::value;
             EXPECT_TRUE(isSame);

--- a/RareCppTest/JsonDefinition.cpp
+++ b/RareCppTest/JsonDefinition.cpp
@@ -1,5 +1,0 @@
-#include "../RareCppLib/Reflect.h"
-#include "../RareCppLib/Json.h"
-using namespace Reflect;
-
-ENABLE_JSON;

--- a/RareCppTest/RareCppTest.vcxproj
+++ b/RareCppTest/RareCppTest.vcxproj
@@ -171,7 +171,6 @@
     <ClCompile Include="FieldTest.cpp" />
     <ClCompile Include="GenericMacroTest.cpp" />
     <ClCompile Include="InheritTest.cpp" />
-    <ClCompile Include="JsonDefinition.cpp" />
     <ClCompile Include="JsonInputTest.cpp" />
     <ClCompile Include="JsonInputTestBuffered.cpp" />
     <ClCompile Include="JsonInputTestUnbuffered.cpp" />

--- a/RareCppTest/RareCppTest.vcxproj.filters
+++ b/RareCppTest/RareCppTest.vcxproj.filters
@@ -58,9 +58,6 @@
     <ClCompile Include="StringBufferTest.cpp">
       <Filter>Source Files\StringBufferTest</Filter>
     </ClCompile>
-    <ClCompile Include="JsonDefinition.cpp">
-      <Filter>Source Files\JsonTest\Definition</Filter>
-    </ClCompile>
     <ClCompile Include="JsonInputTestBuffered.cpp">
       <Filter>Source Files\JsonTest\Definition</Filter>
     </ClCompile>

--- a/RareCppTest/ReflectTest.cpp
+++ b/RareCppTest/ReflectTest.cpp
@@ -333,7 +333,7 @@ TEST(ReflectTest, RfMacroDescribeField)
     using ExpectedStaticValueId = TypePair<StaticValueType, StaticValuePointer>;
 
     using MemberValueReferenceType = decltype(DescribeFieldTest::memberValueReference);
-    using MemberValueReferencePointer = nullptr_t;
+    using MemberValueReferencePointer = std::nullptr_t;
     using ExpectedMemberValueReferenceId = TypePair<MemberValueReferenceType, MemberValueReferencePointer>;
 
     using StaticValueReferenceType = decltype(DescribeFieldTest::staticValueReference);
@@ -463,7 +463,7 @@ TEST(ReflectTest, RfMacroDescribeField)
     
     using ExpectedMemberValueField = Fields::Field<decltype(DescribeFieldTest::memberValue), decltype(&DescribeFieldTest::memberValue), 0, decltype(DescribeFieldTest::Class::NoNote)>;
     using ExpectedStaticValueField = Fields::Field<decltype(DescribeFieldTest::staticValue), decltype(&DescribeFieldTest::staticValue), 1, decltype(DescribeFieldTest::Class::NoNote)>;
-    using ExpectedMemberValueReferenceField = Fields::Field<decltype(DescribeFieldTest::memberValueReference), nullptr_t, 2, decltype(DescribeFieldTest::memberValueReference_note)>;
+    using ExpectedMemberValueReferenceField = Fields::Field<decltype(DescribeFieldTest::memberValueReference), std::nullptr_t, 2, decltype(DescribeFieldTest::memberValueReference_note)>;
     using ExpectedStaticValueReferenceField = Fields::Field<decltype(DescribeFieldTest::staticValueReference), decltype(&DescribeFieldTest::staticValueReference), 3, decltype(DescribeFieldTest::staticValueReference_note)>;
     using ExpectedMemberMethodField = Fields::Field<decltype(&DescribeFieldTest::memberMethod), decltype(&DescribeFieldTest::memberMethod), 4, decltype(DescribeFieldTest::Class::NoNote)>;
     using ExpectedStaticMethodField = Fields::Field<decltype(DescribeFieldTest::staticMethod), decltype(&DescribeFieldTest::staticMethod), 5, decltype(DescribeFieldTest::Class::NoNote)>;
@@ -498,9 +498,9 @@ TEST(ReflectTest, RfMacroDescribeField)
     EXPECT_TRUE(isSame);
     isSame = std::is_same_v<decltype(&DescribeFieldTest::staticValue), StaticValueField::Pointer>;
     EXPECT_TRUE(isSame);
-    isSame = std::is_same_v<nullptr_t, MemberValueReferenceField::Pointer>;
+    isSame = std::is_same_v<std::nullptr_t, MemberValueReferenceField::Pointer>;
     EXPECT_TRUE(isSame);
-    isSame = std::is_same_v<nullptr_t, StaticValueReferenceField::Pointer>;
+    isSame = std::is_same_v<std::nullptr_t, StaticValueReferenceField::Pointer>;
     EXPECT_TRUE(isSame);
     isSame = std::is_same_v<decltype(&DescribeFieldTest::memberMethod), MemberMethodField::Pointer>;
     EXPECT_TRUE(isSame);


### PR DESCRIPTION
- No longer require the ENABLE_JSON macro
- No longer require "using namespace Reflect"
- Fix CMake include list
- Fix for the stricter typename requirements in clang/gcc
- Fully quality nullptr_t for newer clang versions
- Remove some unused code